### PR TITLE
Google Plus dead

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,6 +186,4 @@ Facebook: <https://www.facebook.com/CreativeTim>
 
 Dribbble: <https://dribbble.com/creativetim>
 
-Google+: <https://plus.google.com/+CreativetimPage>
-
 Instagram: <https://instagram.com/creativetimofficial>


### PR DESCRIPTION
Google plus is dead - those links can be removed because they also don't work.